### PR TITLE
fix(ios): avoid main thread warning in completionHandler call

### DIFF
--- a/ios/Plugin/SslSkipPlugin.m
+++ b/ios/Plugin/SslSkipPlugin.m
@@ -31,7 +31,9 @@
 
 - (void)SkipSSLwebView:(WKWebView *)webView didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition disposition, NSURLCredential *credential))completionHandler{
   NSURLCredential * credential = [[NSURLCredential alloc] initWithTrust:[challenge protectionSpace].serverTrust];
-  completionHandler(NSURLSessionAuthChallengeUseCredential, credential);
+  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    completionHandler(NSURLSessionAuthChallengeUseCredential, credential);
+  });
 }
 
 @end


### PR DESCRIPTION
Fix the Running Warning for Security.
`This method should not be called on the main thread as it may lead to UI unresponsiveness. `